### PR TITLE
No-std support for `tracing-tunnel`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,38 @@ jobs:
           command: test
           args: --workspace --all-features --doc
 
+  build-nostd:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-nostd-cargo-build-target
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.nightly }}
+          target: thumbv7m-none-eabi
+          override: true
+          profile: minimal
+
+      - name: Build tunnel
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p tracing-tunnel --lib --no-default-features --features sender --target thumbv7m-none-eabi -Z avoid-dev-deps
+
   document:
     if: github.event_name == 'push'
     needs:
       - build
       - build-msrv
+      - build-nostd
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           command: test
           args: --workspace --all-features --doc
 
-  build-nostd:
+  build-nightly:
     runs-on: ubuntu-latest
 
     steps:
@@ -104,7 +104,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: target
-          key: ${{ runner.os }}-nostd-cargo-build-target
+          key: ${{ runner.os }}-nightly-cargo-build-target
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -119,13 +119,18 @@ jobs:
         with:
           command: build
           args: -p tracing-tunnel --lib --no-default-features --features sender --target thumbv7m-none-eabi -Z avoid-dev-deps
+      - name: Build capture
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p tracing-capture --lib --no-default-features -Z avoid-dev-deps
 
   document:
     if: github.event_name == 'push'
     needs:
       - build
       - build-msrv
-      - build-nostd
+      - build-nightly
     runs-on: ubuntu-latest
 
     steps:

--- a/capture/Cargo.toml
+++ b/capture/Cargo.toml
@@ -23,13 +23,13 @@ tracing-tunnel = { version = "0.1.0", path = "../tunnel" }
 [dependencies.tracing-subscriber]
 version = "0.3.16"
 default-features = false
-features = ["std"]
+features = ["std", "registry"]
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 doc-comment = "0.3.3"
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["registry", "fmt"] }
+tracing-subscriber = { version = "0.3.16", features = ["fmt"] }
 version-sync = "0.9.4"
 
 tracing-tunnel = { version = "0.1.0", path = "../tunnel", features = ["sender", "receiver"] }

--- a/capture/src/lib.rs
+++ b/capture/src/lib.rs
@@ -136,16 +136,13 @@ impl<'a> CapturedEvent<'a> {
     }
 
     /// Iterates over values associated with the event.
-    pub fn values(&self) -> impl Iterator<Item = (&'static str, &TracedValue)> + '_ {
-        self.inner.values.iter().map(|(name, value)| (*name, value))
+    pub fn values(&self) -> impl Iterator<Item = (&str, &TracedValue)> + '_ {
+        self.inner.values.iter()
     }
 
     /// Returns a value for the specified field, or `None` if the value is not defined.
     pub fn value(&self, name: &str) -> Option<&'a TracedValue> {
-        self.inner
-            .values
-            .iter()
-            .find_map(|(s, value)| if *s == name { Some(value) } else { None })
+        self.inner.values.get(name)
     }
 
     /// Returns the message recorded in this event, i.e., the value of the `message` field
@@ -278,16 +275,13 @@ impl<'a> CapturedSpan<'a> {
     }
 
     /// Iterates over values that the span was created with, or which were recorded later.
-    pub fn values(&self) -> impl Iterator<Item = (&'static str, &TracedValue)> + '_ {
-        self.inner.values.iter().map(|(name, value)| (*name, value))
+    pub fn values(&self) -> impl Iterator<Item = (&str, &TracedValue)> + '_ {
+        self.inner.values.iter()
     }
 
     /// Returns a value for the specified field, or `None` if the value is not defined.
     pub fn value(&self, name: &str) -> Option<&'a TracedValue> {
-        self.inner
-            .values
-            .iter()
-            .find_map(|(s, value)| if *s == name { Some(value) } else { None })
+        self.inner.values.get(name)
     }
 
     /// Returns statistics about span operations.

--- a/capture/src/lib.rs
+++ b/capture/src/lib.rs
@@ -136,7 +136,7 @@ impl<'a> CapturedEvent<'a> {
     }
 
     /// Iterates over values associated with the event.
-    pub fn values(&self) -> impl Iterator<Item = (&str, &TracedValue)> + '_ {
+    pub fn values(&self) -> impl Iterator<Item = (&'a str, &'a TracedValue)> + 'a {
         self.inner.values.iter()
     }
 
@@ -275,7 +275,7 @@ impl<'a> CapturedSpan<'a> {
     }
 
     /// Iterates over values that the span was created with, or which were recorded later.
-    pub fn values(&self) -> impl Iterator<Item = (&str, &TracedValue)> + '_ {
+    pub fn values(&self) -> impl Iterator<Item = (&'a str, &'a TracedValue)> + 'a {
         self.inner.values.iter()
     }
 

--- a/capture/src/predicates/tests.rs
+++ b/capture/src/predicates/tests.rs
@@ -178,7 +178,7 @@ fn message_predicates() {
     let predicate = message(eq("completed computations"));
     assert!(predicate.eval(&event));
 
-    storage.events[event_id].values.remove("message");
+    storage.events[event_id].values = TracedValues::from_iter([("val", 42_i64.into())]);
     assert!(!predicate.eval(&storage.event(event_id)));
     storage.events[event_id]
         .values

--- a/tunnel/Cargo.toml
+++ b/tunnel/Cargo.toml
@@ -19,10 +19,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-linked-hash-map = { version = "0.5.6", features = ["serde_impl"] }
 once_cell = { version = "1.15.0", optional = true }
-serde = { version = "1", features = ["derive"] }
-tracing-core = "0.1.30"
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
+tracing-core = { version = "0.1.30", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
@@ -34,11 +33,14 @@ tracing-subscriber = { version = "0.3.16", features = ["registry", "fmt"] }
 version-sync = "0.9.4"
 
 [features]
-default = []
+default = ["std"]
+# Enables std-related functionality. Note that this is required on the `receiver`
+# end of the tunnel.
+std = ["tracing-core/std"]
 # Enables `TracingEventSender`.
 sender = []
 # Enables `TracingEventReceiver` and closely related types.
-receiver = ["once_cell"]
+receiver = ["std", "once_cell"]
 
 [[test]]
 name = "integration"

--- a/tunnel/README.md
+++ b/tunnel/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://github.com/slowli/tracing-toolbox/workflows/CI/badge.svg?branch=main)](https://github.com/slowli/tracing-toolbox/actions)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/slowli/tracing-toolbox#license)
 ![rust 1.60+ required](https://img.shields.io/badge/rust-1.60+-blue.svg?label=Required%20Rust)
+![no_std tested](https://img.shields.io/badge/no__std-tested-green.svg)
 
 **Documentation:**
 [![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://slowli.github.io/tracing-toolbox/tracing_tunnel/)

--- a/tunnel/src/lib.rs
+++ b/tunnel/src/lib.rs
@@ -53,7 +53,19 @@
 //!
 //! # Crate features
 //!
-//! Each of the two major features outlined above is gated by the corresponding opt-in feature.
+//! Each of the two major features outlined above is gated by the corresponding opt-in feature,
+//! [`sender`](#sender) and [`receiver`](#receiver).
+//! Without these features enabled, the crate only provides data types to capture tracing data.
+//!
+//! ## `std`
+//!
+//! *(On by default)*
+//!
+//! Enables support of types from `std`, such as the `Error` trait. Propagates to [`tracing-core`],
+//! enabling errors support there.
+//!
+//! Even if this feature is off, the crate requires the global allocator (i.e., the `alloc` crate)
+//! and `u32` atomics.
 //!
 //! ## `sender`
 //!
@@ -63,9 +75,11 @@
 //!
 //! ## `receiver`
 //!
-//! *(Off by default)*
+//! *(Off by default; requires `std`)*
 //!
-//! Provides [`TracingEventReceiver`].
+//! Provides [`TracingEventReceiver`] and related types.
+//!
+//! [`tracing-core`]: https://docs.rs/tracing-core/0.1/tracing_core
 //!
 //! # Examples
 //!

--- a/tunnel/src/lib.rs
+++ b/tunnel/src/lib.rs
@@ -62,7 +62,7 @@
 //! *(On by default)*
 //!
 //! Enables support of types from `std`, such as the `Error` trait. Propagates to [`tracing-core`],
-//! enabling errors support there.
+//! enabling `Error` support there.
 //!
 //! Even if this feature is off, the crate requires the global allocator (i.e., the `alloc` crate)
 //! and `u32` atomics.

--- a/tunnel/src/lib.rs
+++ b/tunnel/src/lib.rs
@@ -132,6 +132,7 @@
 //! // be persisted, while `local_spans` should be stored in RAM.
 //! ```
 
+#![cfg_attr(not(feature = "std"), no_std)]
 // Documentation settings.
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_root_url = "https://docs.rs/tracing-tunnel/0.1.0")]
@@ -148,6 +149,22 @@ mod receiver;
 mod sender;
 mod types;
 mod value;
+mod values;
+
+// Polyfill for `alloc` types.
+mod alloc {
+    #[cfg(not(feature = "std"))]
+    extern crate alloc;
+    #[cfg(feature = "std")]
+    use std as alloc;
+
+    pub use alloc::{
+        borrow::{Cow, ToOwned},
+        format,
+        string::String,
+        vec::{self, Vec},
+    };
+}
 
 #[cfg(feature = "receiver")]
 pub use crate::receiver::{
@@ -155,12 +172,12 @@ pub use crate::receiver::{
 };
 #[cfg(feature = "sender")]
 pub use crate::sender::TracingEventSender;
+#[cfg(feature = "std")]
+pub use crate::value::TracedError;
 pub use crate::{
-    types::{
-        CallSiteData, CallSiteKind, MetadataId, RawSpanId, TracedValueVisitor, TracedValues,
-        TracingEvent, TracingLevel,
-    },
-    value::{DebugObject, FromTracedValue, TracedError, TracedValue},
+    types::{CallSiteData, CallSiteKind, MetadataId, RawSpanId, TracingEvent, TracingLevel},
+    value::{DebugObject, FromTracedValue, TracedValue},
+    values::{TracedValues, TracedValuesIter},
 };
 
 #[cfg(doctest)]

--- a/tunnel/src/types.rs
+++ b/tunnel/src/types.rs
@@ -1,12 +1,14 @@
 //! Types to carry tracing events over the WASM client-host boundary.
 
-use linked_hash_map::LinkedHashMap;
 use serde::{Deserialize, Serialize};
-use tracing_core::{field::Visit, Field, Level, Metadata};
+use tracing_core::{Level, Metadata};
 
-use std::{borrow::Cow, error, fmt, hash::Hash};
+use core::hash::Hash;
 
-use crate::TracedValue;
+use crate::{
+    alloc::{Cow, String, Vec},
+    TracedValues,
+};
 
 /// ID of a tracing [`Metadata`] record as used in [`TracingEvent`]s.
 pub type MetadataId = u64;
@@ -182,69 +184,4 @@ pub enum TracingEvent {
         /// Values associated with the event.
         values: TracedValues<String>,
     },
-}
-
-/// Collection of named [`TracedValue`]s.
-pub type TracedValues<K> = LinkedHashMap<K, TracedValue>;
-
-#[doc(hidden)] // not public; used by `tracing-capture`
-pub struct TracedValueVisitor<S> {
-    pub values: TracedValues<S>,
-}
-
-impl<S: fmt::Debug + Eq + Hash> fmt::Debug for TracedValueVisitor<S> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("ValueVisitor")
-            .field("values", &self.values)
-            .finish()
-    }
-}
-
-impl<S: Eq + Hash> Default for TracedValueVisitor<S> {
-    fn default() -> Self {
-        Self {
-            values: TracedValues::new(),
-        }
-    }
-}
-
-impl<S: From<&'static str> + Eq + Hash> Visit for TracedValueVisitor<S> {
-    fn record_f64(&mut self, field: &Field, value: f64) {
-        self.values.insert(field.name().into(), value.into());
-    }
-
-    fn record_i64(&mut self, field: &Field, value: i64) {
-        self.values.insert(field.name().into(), value.into());
-    }
-
-    fn record_u64(&mut self, field: &Field, value: u64) {
-        self.values.insert(field.name().into(), value.into());
-    }
-
-    fn record_i128(&mut self, field: &Field, value: i128) {
-        self.values.insert(field.name().into(), value.into());
-    }
-
-    fn record_u128(&mut self, field: &Field, value: u128) {
-        self.values.insert(field.name().into(), value.into());
-    }
-
-    fn record_bool(&mut self, field: &Field, value: bool) {
-        self.values.insert(field.name().into(), value.into());
-    }
-
-    fn record_str(&mut self, field: &Field, value: &str) {
-        self.values.insert(field.name().into(), value.into());
-    }
-
-    fn record_error(&mut self, field: &Field, value: &(dyn error::Error + 'static)) {
-        self.values
-            .insert(field.name().into(), TracedValue::error(value));
-    }
-
-    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        self.values
-            .insert(field.name().into(), TracedValue::debug(value));
-    }
 }

--- a/tunnel/src/value.rs
+++ b/tunnel/src/value.rs
@@ -15,6 +15,7 @@ mod error {
     /// (De)serializable presentation for an error recorded as a value in a tracing span or event.
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[non_exhaustive]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub struct TracedError {
         /// Error message produced by its [`Display`](fmt::Display) implementation.
         pub message: String,
@@ -87,6 +88,7 @@ pub enum TracedValue {
     Object(DebugObject),
     /// Opaque error.
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     Error(TracedError),
 }
 

--- a/tunnel/src/values.rs
+++ b/tunnel/src/values.rs
@@ -1,0 +1,298 @@
+//! `TracedValues` and closely related types.
+
+use serde::{
+    de::{MapAccess, Visitor},
+    ser::SerializeMap,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use tracing_core::{
+    field::{Field, ValueSet, Visit},
+    span::Record,
+    Event,
+};
+
+use core::{fmt, mem, ops, slice};
+
+use crate::{
+    alloc::{vec, String, Vec},
+    TracedValue,
+};
+
+/// Collection of named [`TracedValue`]s.
+///
+/// Functionally this collection is similar to a `HashMap<S, TracedValue>`,
+/// with the key being that the order of [iteration](Self::iter()) is the insertion order.
+/// If a value is updated, including via [`Extend`] etc., it preserves its old placement.
+#[derive(Clone)]
+pub struct TracedValues<S> {
+    inner: Vec<(S, TracedValue)>,
+}
+
+impl<S> Default for TracedValues<S> {
+    fn default() -> Self {
+        Self { inner: Vec::new() }
+    }
+}
+
+impl<S: AsRef<str>> fmt::Debug for TracedValues<S> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut map = formatter.debug_map();
+        for (key, value) in &self.inner {
+            map.entry(&key.as_ref(), value);
+        }
+        map.finish()
+    }
+}
+
+impl<S: From<&'static str> + AsRef<str>> TracedValues<S> {
+    /// Creates traced values from the specified value set.
+    pub fn from_values(values: &ValueSet<'_>) -> Self {
+        let mut visitor = TracedValueVisitor {
+            values: Self::default(),
+        };
+        values.record(&mut visitor);
+        visitor.values
+    }
+
+    /// Creates traced values from the specified record.
+    pub fn from_record(values: &Record<'_>) -> Self {
+        let mut visitor = TracedValueVisitor {
+            values: Self::default(),
+        };
+        values.record(&mut visitor);
+        visitor.values
+    }
+
+    /// Creates traced values from the values in the specified event.
+    pub fn from_event(event: &Event<'_>) -> Self {
+        let mut visitor = TracedValueVisitor {
+            values: Self::default(),
+        };
+        event.record(&mut visitor);
+        visitor.values
+    }
+}
+
+impl<S: AsRef<str>> TracedValues<S> {
+    /// Creates new empty values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of stored values.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Checks whether this collection of values is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns the value with the specified name, or `None` if it not set.
+    pub fn get(&self, key: &str) -> Option<&TracedValue> {
+        self.inner.iter().find_map(|(existing_key, value)| {
+            if existing_key.as_ref() == key {
+                Some(value)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Iterates over the contained name-value pairs.
+    pub fn iter(&self) -> TracedValuesIter<'_, S> {
+        TracedValuesIter {
+            inner: self.inner.iter(),
+        }
+    }
+
+    /// Inserts a value with the specified name. If a value with the same name was present
+    /// previously, it is overwritten.
+    pub fn insert(&mut self, key: S, value: TracedValue) -> Option<TracedValue> {
+        let position = self
+            .inner
+            .iter()
+            .position(|(existing_key, _)| existing_key.as_ref() == key.as_ref());
+        if let Some(position) = position {
+            let place = &mut self.inner[position].1;
+            Some(mem::replace(place, value))
+        } else {
+            self.inner.push((key, value));
+            None
+        }
+    }
+}
+
+impl<S: AsRef<str>> ops::Index<&str> for TracedValues<S> {
+    type Output = TracedValue;
+
+    fn index(&self, index: &str) -> &Self::Output {
+        self.get(index)
+            .unwrap_or_else(|| panic!("value `{index}` is not defined"))
+    }
+}
+
+impl<S: AsRef<str>> FromIterator<(S, TracedValue)> for TracedValues<S> {
+    fn from_iter<I: IntoIterator<Item = (S, TracedValue)>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let mut this = Self::new();
+        this.extend(iter);
+        this
+    }
+}
+
+impl<S: AsRef<str>> Extend<(S, TracedValue)> for TracedValues<S> {
+    fn extend<I: IntoIterator<Item = (S, TracedValue)>>(&mut self, iter: I) {
+        let iter = iter.into_iter();
+        self.inner.reserve(iter.size_hint().0);
+        for (name, value) in iter {
+            self.insert(name, value);
+        }
+    }
+}
+
+impl<S> IntoIterator for TracedValues<S> {
+    type Item = (S, TracedValue);
+    type IntoIter = vec::IntoIter<(S, TracedValue)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
+/// Iterator over name-value references returned from [`TracedValues::iter()`].
+#[derive(Debug)]
+pub struct TracedValuesIter<'a, S> {
+    inner: slice::Iter<'a, (S, TracedValue)>,
+}
+
+impl<'a, S: AsRef<str>> Iterator for TracedValuesIter<'a, S> {
+    type Item = (&'a str, &'a TracedValue);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|(name, value)| (name.as_ref(), value))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<'a, S: AsRef<str>> DoubleEndedIterator for TracedValuesIter<'a, S> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|(name, value)| (name.as_ref(), value))
+    }
+}
+
+impl<'a, S: AsRef<str>> ExactSizeIterator for TracedValuesIter<'a, S> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+impl<'a, S: AsRef<str>> IntoIterator for &'a TracedValues<S> {
+    type Item = (&'a str, &'a TracedValue);
+    type IntoIter = TracedValuesIter<'a, S>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<S: AsRef<str>> Serialize for TracedValues<S> {
+    fn serialize<Ser: Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
+        let mut map = serializer.serialize_map(Some(self.len()))?;
+        for (name, value) in self {
+            map.serialize_entry(name, value)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for TracedValues<String> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct MapVisitor;
+
+        impl<'v> Visitor<'v> for MapVisitor {
+            type Value = TracedValues<String>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("map of name-value entries")
+            }
+
+            fn visit_map<A: MapAccess<'v>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                let mut values = TracedValues {
+                    inner: Vec::with_capacity(map.size_hint().unwrap_or(0)),
+                };
+                while let Some((name, value)) = map.next_entry()? {
+                    values.insert(name, value);
+                }
+                Ok(values)
+            }
+        }
+
+        deserializer.deserialize_map(MapVisitor)
+    }
+}
+
+struct TracedValueVisitor<S> {
+    values: TracedValues<S>,
+}
+
+impl<S: AsRef<str>> fmt::Debug for TracedValueVisitor<S> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ValueVisitor")
+            .field("values", &self.values)
+            .finish()
+    }
+}
+
+impl<S: From<&'static str> + AsRef<str>> Visit for TracedValueVisitor<S> {
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.values.insert(field.name().into(), value.into());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.values.insert(field.name().into(), value.into());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.values.insert(field.name().into(), value.into());
+    }
+
+    fn record_i128(&mut self, field: &Field, value: i128) {
+        self.values.insert(field.name().into(), value.into());
+    }
+
+    fn record_u128(&mut self, field: &Field, value: u128) {
+        self.values.insert(field.name().into(), value.into());
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.values.insert(field.name().into(), value.into());
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.values.insert(field.name().into(), value.into());
+    }
+
+    #[cfg(feature = "std")]
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        self.values
+            .insert(field.name().into(), TracedValue::error(value));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.values
+            .insert(field.name().into(), TracedValue::debug(value));
+    }
+}

--- a/tunnel/tests/integration/main.rs
+++ b/tunnel/tests/integration/main.rs
@@ -176,10 +176,7 @@ fn event_fields_have_same_order() {
     });
 
     for fields in debug_fields {
-        let fields: Vec<_> = fields
-            .iter()
-            .map(|(name, value)| (name.as_str(), value))
-            .collect();
+        let fields: Vec<_> = fields.iter().collect();
         assert_matches!(
             fields.as_slice(),
             [


### PR DESCRIPTION
...and a fix for `tracing-subscriber` features in `tracing-capture` (the features should include `registry`, but this was not the case previously).