### PR TITLE
Prepare 0.2.0-beta.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-capture"
-version = "0.1.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "assert_matches",
  "doc-comment",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-tunnel"
-version = "0.1.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "assert_matches",
  "doc-comment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["capture", "tunnel"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0-beta.1"
 edition = "2021"
 rust-version = "1.70"
 authors = [

--- a/capture/CHANGELOG.md
+++ b/capture/CHANGELOG.md
@@ -5,6 +5,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.2.0-beta.1 - 2024-03-03
+
 ### Added
 
 - Support "follows from" relations between spans.

--- a/capture/Cargo.toml
+++ b/capture/Cargo.toml
@@ -21,7 +21,7 @@ tracing-core.workspace = true
 tracing-subscriber = { workspace = true, features = ["std", "registry"] }
 # Private dependencies.
 id-arena = "2.2.1"
-tracing-tunnel = { version = "0.1.0", path = "../tunnel" }
+tracing-tunnel = { version = "0.2.0-beta.1", path = "../tunnel" }
 
 [dev-dependencies]
 assert_matches.workspace = true
@@ -30,4 +30,4 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["default"] }
 version-sync.workspace = true
 
-tracing-tunnel = { version = "0.1.0", path = "../tunnel", features = ["sender", "receiver"] }
+tracing-tunnel = { version = "0.2.0-beta.1", path = "../tunnel", features = ["sender", "receiver"] }

--- a/capture/README.md
+++ b/capture/README.md
@@ -22,7 +22,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-tracing-capture = "0.1.0"
+tracing-capture = "0.2.0-beta.1"
 ```
 
 ### Capturing spans for test assertions

--- a/capture/src/lib.rs
+++ b/capture/src/lib.rs
@@ -54,7 +54,7 @@
 //! [`tracing-fluent-assertions`]: https://docs.rs/tracing-fluent-assertions
 
 // Documentation settings.
-#![doc(html_root_url = "https://docs.rs/tracing-capture/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-capture/0.2.0-beta.1")]
 // Linter settings.
 #![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]

--- a/tunnel/CHANGELOG.md
+++ b/tunnel/CHANGELOG.md
@@ -5,6 +5,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.2.0-beta.1 - 2024-03-03
+
 ### Added
 
 - Expose `TracingEvent::normalize()` to transform a sequence of events so that

--- a/tunnel/README.md
+++ b/tunnel/README.md
@@ -32,7 +32,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-tracing-tunnel = "0.1.0"
+tracing-tunnel = "0.2.0-beta.1"
 ```
 
 Note that the both pieces of functionality described above are gated behind opt-in features;

--- a/tunnel/src/lib.rs
+++ b/tunnel/src/lib.rs
@@ -145,7 +145,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // Documentation settings.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/tracing-tunnel/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-tunnel/0.2.0-beta.1")]
 // Linter settings.
 #![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]


### PR DESCRIPTION
## What?

Prepares the crates in this repository for the next pre-release (0.2.0-beta.1).

## Why?

This release will include some fixes and new features.