### PR TITLE
Fix race condition in TracingEventSender metadata registration

### DIFF
--- a/tunnel/src/lib.rs
+++ b/tunnel/src/lib.rs
@@ -152,7 +152,9 @@ pub use crate::receiver::{
     LocalSpans, PersistedMetadata, PersistedSpans, ReceiveError, TracingEventReceiver,
 };
 #[cfg(feature = "sender")]
-pub use crate::sender::TracingEventSender;
+pub use crate::sender::{EventSync, TracingEventSender};
+#[cfg(all(feature = "sender", feature = "std"))]
+pub use crate::sender::{SyncTracingEventSender, Synced};
 #[cfg(feature = "std")]
 pub use crate::value::TracedError;
 pub use crate::{

--- a/tunnel/src/lib.rs
+++ b/tunnel/src/lib.rs
@@ -88,7 +88,7 @@
 //! ```
 //! # use assert_matches::assert_matches;
 //! # use std::sync::mpsc;
-//! use tracing_tunnel::{TracingEvent, TracingEventSender, TracingEventReceiver};
+//! use tracing_tunnel::{TracingEvent, TracingEventSender};
 //!
 //! // Let's collect tracing events using an MPSC channel.
 //! let (events_sx, events_rx) = mpsc::sync_channel(10);
@@ -110,6 +110,21 @@
 //!     .filter(|event| matches!(event, TracingEvent::NewSpan { .. }))
 //!     .count();
 //! assert_eq!(span_count, 1);
+//! ```
+//!
+//! In multithreaded environments when tracing events / spans are produced by multiple threads,
+//! you should use `TracingEventSender::sync()` constructor instead of `new()`. This will ensure that
+//! metadata registration events are always emitted before events referencing this metadata.
+//! This requires the `std` crate feature.
+//!
+//! ```
+//! # use tracing_tunnel::{TracingEvent, TracingEventSender};
+//! # use std::sync::mpsc;
+//! let (events_sx, events_rx) = mpsc::sync_channel(10);
+//! let subscriber = TracingEventSender::sync(move |event| {
+//!     events_sx.send(event).ok();
+//! });
+//! // Handle the `subscriber` and `events_rx` in the same way...
 //! ```
 //!
 //! ## Receiving events from `TracingEventReceiver`
@@ -151,10 +166,10 @@
 pub use crate::receiver::{
     LocalSpans, PersistedMetadata, PersistedSpans, ReceiveError, TracingEventReceiver,
 };
+#[cfg(all(feature = "sender", feature = "std"))]
+pub use crate::sender::Synced;
 #[cfg(feature = "sender")]
 pub use crate::sender::{EventSync, TracingEventSender};
-#[cfg(all(feature = "sender", feature = "std"))]
-pub use crate::sender::{SyncTracingEventSender, Synced};
 #[cfg(feature = "std")]
 pub use crate::value::TracedError;
 pub use crate::{

--- a/tunnel/src/sender/mod.rs
+++ b/tunnel/src/sender/mod.rs
@@ -42,7 +42,7 @@ impl TracingEvent {
 
 /// Event synchronization used by [`TracingEventSender`].
 ///
-/// Synchronization must be necessary in a multithreaded environments, where events may arrive from
+/// Synchronization might be necessary in a multithreaded environments, where events may arrive from
 /// different threads out of order. This functionality is encapsulated in the (`std`-dependent) [`Synced`]
 /// implementation.
 ///
@@ -110,10 +110,6 @@ pub struct TracingEventSender<F = fn(TracingEvent), S = ()> {
     sync: S,
 }
 
-/// [`TracingEventSender`] variation with synchronized event processing. Most fitting for multithreaded environments.
-#[cfg(feature = "std")]
-pub type SyncTracingEventSender<F = fn(TracingEvent)> = TracingEventSender<F, Synced>;
-
 impl<F: Fn(TracingEvent) + 'static> TracingEventSender<F> {
     /// Creates a subscriber with the specified "on event" hook.
     pub fn new(on_event: F) -> Self {
@@ -126,7 +122,7 @@ impl<F: Fn(TracingEvent) + 'static> TracingEventSender<F> {
 }
 
 #[cfg(feature = "std")]
-impl<F: Fn(TracingEvent) + 'static> SyncTracingEventSender<F> {
+impl<F: Fn(TracingEvent) + 'static> TracingEventSender<F, Synced> {
     /// Creates a subscriber with the specified "on event" hook and synchronized event processing.
     pub fn sync(on_event: F) -> Self {
         Self {

--- a/tunnel/src/sender/mod.rs
+++ b/tunnel/src/sender/mod.rs
@@ -1,14 +1,18 @@
 //! Client-side subscriber.
 
 use core::sync::atomic::{AtomicU32, Ordering};
-use std::{collections::HashSet, sync::Mutex};
 
 use tracing_core::{
     span::{Attributes, Id, Record},
     Event, Interest, Metadata, Subscriber,
 };
 
+#[cfg(feature = "std")]
+pub use self::sync::Synced;
 use crate::{CallSiteData, MetadataId, RawSpanId, TracedValues, TracingEvent};
+
+#[cfg(feature = "std")]
+mod sync;
 
 impl TracingEvent {
     fn new_span(span: &Attributes<'_>, metadata_id: MetadataId, id: RawSpanId) -> Self {
@@ -36,6 +40,57 @@ impl TracingEvent {
     }
 }
 
+/// Event synchronization used by [`TracingEventSender`].
+///
+/// Synchronization must be necessary in a multithreaded environments, where events may arrive from
+/// different threads out of order. This functionality is encapsulated in the (`std`-dependent) [`Synced`]
+/// implementation.
+///
+/// For single-threaded environments (e.g., WASM), there is the no-op `()` implementation.
+pub trait EventSync: 'static + Send + Sync {
+    /// Called when a new callsite event arrives.
+    #[doc(hidden)] // implementation detail
+    fn register_callsite(
+        &self,
+        metadata: &'static Metadata<'static>,
+        sender: impl Fn(TracingEvent),
+    );
+
+    /// Called when a new span or event arrives.
+    #[doc(hidden)] // implementation detail
+    fn ensure_callsite_registered(
+        &self,
+        metadata: &'static Metadata<'static>,
+        sender: impl Fn(TracingEvent),
+    );
+}
+
+/// Default implementation that does not perform any synchronization.
+impl EventSync for () {
+    fn register_callsite(
+        &self,
+        metadata: &'static Metadata<'static>,
+        sender: impl Fn(TracingEvent),
+    ) {
+        sender(TracingEvent::NewCallSite {
+            id: metadata_id(metadata),
+            data: CallSiteData::from(metadata),
+        });
+    }
+
+    fn ensure_callsite_registered(
+        &self,
+        _metadata: &'static Metadata<'static>,
+        _sender: impl Fn(TracingEvent),
+    ) {
+        // Do nothing
+    }
+}
+
+fn metadata_id(metadata: &'static Metadata<'static>) -> MetadataId {
+    metadata as *const _ as MetadataId
+}
+
 /// Tracing [`Subscriber`] that converts tracing events into (de)serializable [presentation]
 /// that can be sent elsewhere using a customizable hook.
 ///
@@ -49,13 +104,15 @@ impl TracingEvent {
 /// [presentation]: TracingEvent
 /// [Tardigrade client library]: https://github.com/slowli/tardigrade
 #[derive(Debug)]
-pub struct TracingEventSender<F = fn(TracingEvent)> {
+pub struct TracingEventSender<F = fn(TracingEvent), S = ()> {
     next_span_id: AtomicU32,
     on_event: F,
-    /// Track registered callsite IDs to prevent race conditions.
-    /// Uses Mutex to ensure synchronous registration before dependent events.
-    registered_callsites: Mutex<HashSet<MetadataId>>,
+    sync: S,
 }
+
+/// [`TracingEventSender`] variation with synchronized event processing. Most fitting for multithreaded environments.
+#[cfg(feature = "std")]
+pub type SyncTracingEventSender<F = fn(TracingEvent)> = TracingEventSender<F, Synced>;
 
 impl<F: Fn(TracingEvent) + 'static> TracingEventSender<F> {
     /// Creates a subscriber with the specified "on event" hook.
@@ -63,51 +120,33 @@ impl<F: Fn(TracingEvent) + 'static> TracingEventSender<F> {
         Self {
             next_span_id: AtomicU32::new(1), // 0 is invalid span ID
             on_event,
-            registered_callsites: Mutex::new(HashSet::new()),
-        }
-    }
-
-    fn metadata_id(metadata: &'static Metadata<'static>) -> MetadataId {
-        metadata as *const _ as MetadataId
-    }
-
-    fn send(&self, event: TracingEvent) {
-        (self.on_event)(event);
-    }
-
-    /// Ensures that the callsite for the given metadata is registered.
-    /// This method is synchronous and prevents race conditions where
-    /// `NewSpan` or `NewEvent` events arrive before their `NewCallSite` dependencies.
-    fn ensure_callsite_registered(&self, metadata: &'static Metadata<'static>) {
-        let metadata_id = Self::metadata_id(metadata);
-
-        // Fast path: check if already registered without lock contention
-        {
-            let registered = self.registered_callsites.lock().unwrap();
-            if registered.contains(&metadata_id) {
-                return;
-            }
-        }
-
-        // Slow path: register the callsite
-        let mut registered = self.registered_callsites.lock().unwrap();
-
-        // Double-check in case another thread registered it while we waited for the lock
-        if !registered.contains(&metadata_id) {
-            // Send NewCallSite event before marking as registered
-            self.send(TracingEvent::NewCallSite {
-                id: metadata_id,
-                data: CallSiteData::from(metadata),
-            });
-            registered.insert(metadata_id);
+            sync: (),
         }
     }
 }
 
-impl<F: Fn(TracingEvent) + 'static> Subscriber for TracingEventSender<F> {
+#[cfg(feature = "std")]
+impl<F: Fn(TracingEvent) + 'static> SyncTracingEventSender<F> {
+    /// Creates a subscriber with the specified "on event" hook and synchronized event processing.
+    pub fn sync(on_event: F) -> Self {
+        Self {
+            next_span_id: AtomicU32::new(1), // 0 is invalid span ID
+            on_event,
+            sync: Synced::default(),
+        }
+    }
+}
+
+impl<F: Fn(TracingEvent) + 'static, S: EventSync> TracingEventSender<F, S> {
+    fn send(&self, event: TracingEvent) {
+        (self.on_event)(event);
+    }
+}
+
+impl<F: Fn(TracingEvent) + 'static, S: EventSync> Subscriber for TracingEventSender<F, S> {
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         // Ensure callsite is registered synchronously
-        self.ensure_callsite_registered(metadata);
+        self.sync.register_callsite(metadata, &self.on_event);
         Interest::always()
     }
 
@@ -119,10 +158,11 @@ impl<F: Fn(TracingEvent) + 'static> Subscriber for TracingEventSender<F> {
         // Ensure callsite is registered before sending NewSpan event.
         // Practice shows that the caller may not synchronize its register_callsite calls,
         // allowing a new_span call to take effect before the registration completes.
-        // We guarantee that references are valid, even when multi-threaded.
-        self.ensure_callsite_registered(span.metadata());
+        // We guarantee that references are valid, even when multithreaded.
+        self.sync
+            .ensure_callsite_registered(span.metadata(), &self.on_event);
 
-        let metadata_id = Self::metadata_id(span.metadata());
+        let metadata_id = metadata_id(span.metadata());
         let span_id = u64::from(self.next_span_id.fetch_add(1, Ordering::SeqCst));
         self.send(TracingEvent::new_span(span, metadata_id, span_id));
         Id::from_u64(span_id)
@@ -144,9 +184,10 @@ impl<F: Fn(TracingEvent) + 'static> Subscriber for TracingEventSender<F> {
         // Practice shows that the caller may not synchronize its register_callsite calls,
         // allowing an event call to take effect before the registration completes.
         // We guarantee that references are valid, even when multi-threaded.
-        self.ensure_callsite_registered(event.metadata());
+        self.sync
+            .ensure_callsite_registered(event.metadata(), &self.on_event);
 
-        let metadata_id = Self::metadata_id(event.metadata());
+        let metadata_id = metadata_id(event.metadata());
         self.send(TracingEvent::new_event(event, metadata_id));
     }
 

--- a/tunnel/src/sender/sync.rs
+++ b/tunnel/src/sender/sync.rs
@@ -1,0 +1,55 @@
+//! `Mutex`-based synchronization.
+
+use std::{collections::HashSet, sync::Mutex};
+
+use tracing_core::Metadata;
+
+use super::{metadata_id, EventSync};
+use crate::{CallSiteData, MetadataId, TracingEvent};
+
+/// Mutex-based [`EventSync`] implementation that can be used by [`TracingEventSender`](super::TracingEventSender).
+#[derive(Debug, Default)]
+pub struct Synced(Mutex<HashSet<MetadataId>>);
+
+impl EventSync for Synced {
+    fn register_callsite(
+        &self,
+        metadata: &'static Metadata<'static>,
+        sender: impl Fn(TracingEvent),
+    ) {
+        // We treat both trait methods in the same way since they may arrive out of order.
+        self.ensure_callsite_registered(metadata, sender);
+    }
+
+    /// Ensures that the callsite for the given metadata is registered.
+    /// This method is synchronous and prevents race conditions where
+    /// `NewSpan` or `NewEvent` events arrive before their `NewCallSite` dependencies.
+    fn ensure_callsite_registered(
+        &self,
+        metadata: &'static Metadata<'static>,
+        sender: impl Fn(TracingEvent),
+    ) {
+        let metadata_id = metadata_id(metadata);
+
+        // Fast path: check if already registered without lock contention
+        {
+            let registered = self.0.lock().unwrap();
+            if registered.contains(&metadata_id) {
+                return;
+            }
+        }
+
+        // Slow path: register the callsite
+        let mut registered = self.0.lock().unwrap();
+
+        // Double-check in case another thread registered it while we waited for the lock
+        if !registered.contains(&metadata_id) {
+            // Send NewCallSite event before marking as registered
+            sender(TracingEvent::NewCallSite {
+                id: metadata_id,
+                data: CallSiteData::from(metadata),
+            });
+            registered.insert(metadata_id);
+        }
+    }
+}

--- a/tunnel/tests/integration/main.rs
+++ b/tunnel/tests/integration/main.rs
@@ -3,7 +3,9 @@
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
-    iter, thread,
+    iter,
+    sync::mpsc,
+    thread,
 };
 
 use assert_matches::assert_matches;
@@ -303,20 +305,20 @@ fn concurrent_senders() {
 #[test]
 #[allow(clippy::needless_collect)] // necessary for threads to be concurrent
 fn concurrent_senders_stress_test() {
-    Lazy::force(&EVENTS);
-
     // Stress test with more threads and rapid span creation to increase
     // likelihood of race condition between NewCallSite and NewSpan events
     const NUM_THREADS: usize = 20;
     const ITERATIONS: usize = 10;
 
+    Lazy::force(&EVENTS);
+
     let threads: Vec<_> = (0..NUM_THREADS)
         .map(|thread_id| {
             thread::spawn(move || {
                 // Use single sender per thread to avoid span ID conflicts
-                let (events_sx, events_rx) = std::sync::mpsc::sync_channel(512);
+                let (events_sender, events_receiver) = mpsc::sync_channel(512);
                 let sender = TracingEventSender::new(move |event| {
-                    events_sx.send(event).unwrap();
+                    events_sender.send(event).unwrap();
                 });
 
                 tracing::subscriber::with_default(sender, || {
@@ -337,7 +339,7 @@ fn concurrent_senders_stress_test() {
                     }
                 });
 
-                events_rx.iter().collect()
+                events_receiver.iter().collect()
             })
         })
         .collect();
@@ -349,12 +351,8 @@ fn concurrent_senders_stress_test() {
 
     // Validate each thread's events individually
     for (thread_idx, events) in all_events.iter().enumerate() {
-        if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            assert_valid_refs(events);
-        })) {
-            eprintln!("Thread {} events failed validation", thread_idx);
-            std::panic::resume_unwind(e);
-        }
+        println!("thread_idx={thread_idx}");
+        assert_valid_refs(events);
         assert_span_management(events);
     }
 }
@@ -362,7 +360,7 @@ fn concurrent_senders_stress_test() {
 fn assert_valid_refs(events: &[TracingEvent]) {
     let mut call_site_ids = HashSet::new();
     let mut span_ids = HashSet::new();
-    for (i, event) in events.iter().enumerate() {
+    for event in events {
         match event {
             TracingEvent::NewCallSite { id, .. } => {
                 call_site_ids.insert(*id);
@@ -372,31 +370,21 @@ fn assert_valid_refs(events: &[TracingEvent]) {
                 id, metadata_id, ..
             } => {
                 assert!(span_ids.insert(*id));
-                if !call_site_ids.contains(metadata_id) {
-                    // Enhanced error reporting for potential race condition detection
-                    eprintln!("Event ordering issue detected at event {}: NewSpan references unknown metadata_id {}", i, metadata_id);
-                    eprintln!("Known call site IDs: {:?}", call_site_ids);
-                    eprintln!(
-                        "Event context (events {}..{}):",
-                        i.saturating_sub(3),
-                        (i + 3).min(events.len())
-                    );
-                    for (j, ctx_event) in events[i.saturating_sub(3)..(i + 3).min(events.len())]
-                        .iter()
-                        .enumerate()
-                    {
-                        let event_idx = i.saturating_sub(3) + j;
-                        let marker = if event_idx == i { " >>> " } else { "     " };
-                        eprintln!("{}[{}] {:?}", marker, event_idx, ctx_event);
-                    }
-                    panic!("NewSpan event references unknown metadata ID {}: this may be indicative of a race condition where NewSpan arrived before NewCallSite", metadata_id);
-                }
+                assert!(
+                    call_site_ids.contains(metadata_id),
+                    "NewSpan event references unknown metadata ID {metadata_id}: this may be indicative of a race condition \
+                     where NewSpan arrived before NewCallSite.\n\
+                     Events: {events:#?}\n\
+                     Call site IDs: {call_site_ids:#?}"
+                );
             }
             TracingEvent::NewEvent { metadata_id, .. } => {
-                if !call_site_ids.contains(metadata_id) {
-                    eprintln!("Event ordering issue detected at event {}: NewEvent references unknown metadata_id {}", i, metadata_id);
-                    panic!("NewEvent references unknown metadata ID {}: this may be indicative of a race condition", metadata_id);
-                }
+                assert!(
+                    call_site_ids.contains(metadata_id),
+                    "NewEvent references unknown metadata ID {metadata_id}: this may be indicative of a race condition\n\
+                     Events: {events:#?}\n\
+                     Call site IDs: {call_site_ids:#?}"
+                );
             }
             _ => { /* do nothing */ }
         }

--- a/tunnel/tests/integration/main.rs
+++ b/tunnel/tests/integration/main.rs
@@ -317,7 +317,8 @@ fn concurrent_senders_stress_test() {
             thread::spawn(move || {
                 // Use single sender per thread to avoid span ID conflicts
                 let (events_sender, events_receiver) = mpsc::sync_channel(512);
-                let sender = TracingEventSender::new(move |event| {
+                // Note: the test should fail with the `TracingEventSender::new()` constructor.
+                let sender = TracingEventSender::sync(move |event| {
                     events_sender.send(event).unwrap();
                 });
 


### PR DESCRIPTION

## What?



<!-- Briefly describe changes in the PR. If there are several things, organize them as a list. -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- If applicable, attach related issue(s) -->

Ensure the correct ordering of NewCallSite and NewSpan/NewEvent events.

## Why?

Practice shows that callers may not synchronize register_callsite calls, allowing new_span/event calls to take effect before registration completes. Instead of weakening the stream format to handle out-of-order messages, we guarantee that metadata references are always valid.

This fixes error messages that manifest in the receiver as for example:

    unknown metadata ID: 94397704869712

### Pros/cons

Pro:
- Makes it so that the receiver can read events from multi-threaded applications. Messages don't get lost because of missing metadata.

Con:
- Minor synchronization overhead


<!-- What is the motivation behind the PR? -->
<!-- If applicable (e.g., for PRs implementing a large new feature), describe potential alternatives
and their pros / cons. -->
<!-- Example: PR templates simplify contributions to the project and structure it commit log. -->

## Context

- Different failure mode, but similar to #74 
- Applied in the fix for https://github.com/nixops4/nixops4/issues/86
- [Tagged](https://github.com/roberth/tracing-toolbox/releases/tag/0.1.99-fork-0) in fork