### PR TITLE
TracingEventReceiver: Explicit parent for unconnected spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,24 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_matches"
@@ -25,26 +31,26 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -72,42 +78,93 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.15.2"
+name = "getrandom"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -117,109 +174,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "id-arena"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -228,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -238,25 +257,34 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "insta"
-version = "1.43.2"
+version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
 dependencies = [
  "console",
  "once_cell",
  "serde",
  "similar",
+ "tempfile",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "lazy_static"
@@ -265,28 +293,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.169"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nu-ansi-term"
@@ -294,32 +334,41 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "predicates"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -327,15 +376,25 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -353,18 +412,24 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -374,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -385,15 +450,28 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -426,10 +504,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.8"
+name = "serde_json"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -445,27 +536,27 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.94"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -474,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -484,20 +575,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.8"
+name = "tempfile"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -517,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
@@ -539,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -550,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -576,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -597,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -618,6 +721,7 @@ dependencies = [
  "insta",
  "once_cell",
  "serde",
+ "thread_local",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -626,32 +730,33 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -661,9 +766,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-sync"
@@ -681,12 +786,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -763,24 +935,105 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -788,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -800,18 +1053,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -820,10 +1073,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -832,11 +1096,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/capture/tests/integration/main.rs
+++ b/capture/tests/integration/main.rs
@@ -106,7 +106,7 @@ fn recorded_span_values_are_restored() {
         },
         TracingEvent::NewEvent {
             metadata_id: 1,
-            parent: None,
+            parent: Some(0),
             values: TracedValues::from_iter([("message".to_owned(), TracedValue::from("test"))]),
         },
         TracingEvent::SpanExited { id: 0 },
@@ -115,7 +115,7 @@ fn recorded_span_values_are_restored() {
     let storage = SharedStorage::default();
     let subscriber = Registry::default().with(CaptureLayer::new(&storage));
     tracing::subscriber::with_default(subscriber, || {
-        let mut receiver = TracingEventReceiver::new(metadata, spans, LocalSpans::default());
+        let mut receiver = TracingEventReceiver::new(metadata, spans, LocalSpans::default(), None);
         for event in more_events {
             receiver.receive(event);
         }
@@ -179,7 +179,7 @@ fn spans_are_exited_on_receiver_drop() {
         TracingEvent::SpanEntered { id: 1 },
         TracingEvent::SpanEntered { id: 0 },
     ];
-    let mut receiver = TracingEventReceiver::new(metadata, spans, local_spans);
+    let mut receiver = TracingEventReceiver::new(metadata, spans, local_spans, None);
     for event in more_events {
         receiver.receive(event);
     }

--- a/tunnel/Cargo.toml
+++ b/tunnel/Cargo.toml
@@ -24,6 +24,7 @@ maintenance = { status = "experimental" }
 serde = { workspace = true, features = ["alloc", "derive"] }
 tracing-core.workspace = true
 # Private dependencies.
+thread_local = { version = "1.1.8", optional = true }
 once_cell = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -43,7 +44,7 @@ default = ["std"]
 # end of the tunnel.
 std = ["tracing-core/std"]
 # Enables `TracingEventSender`.
-sender = []
+sender = ["thread_local"]
 # Enables `TracingEventReceiver` and closely related types.
 receiver = ["std", "once_cell"]
 

--- a/tunnel/src/lib.rs
+++ b/tunnel/src/lib.rs
@@ -167,6 +167,8 @@ mod receiver;
 #[cfg(feature = "sender")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sender")))]
 mod sender;
+#[cfg(feature = "sender")]
+mod stack;
 mod types;
 mod value;
 mod values;

--- a/tunnel/src/receiver/mod.rs
+++ b/tunnel/src/receiver/mod.rs
@@ -256,6 +256,7 @@ pub struct TracingEventReceiver {
     metadata: HashMap<MetadataId, &'static Metadata<'static>>,
     spans: PersistedSpans,
     local_spans: LocalSpans,
+    root_span: Option<Id>,
     current_execution: CurrentExecution,
 }
 
@@ -276,12 +277,14 @@ impl TracingEventReceiver {
         metadata: PersistedMetadata,
         spans: PersistedSpans,
         local_spans: LocalSpans,
+        root_span: Option<Id>,
     ) -> Self {
         let mut this = Self {
             metadata: HashMap::new(),
             spans,
             local_spans,
             current_execution: CurrentExecution::default(),
+            root_span,
         };
 
         for (id, data) in metadata.inner {
@@ -400,8 +403,10 @@ impl TracingEventReceiver {
         let value_set = Self::create_values(metadata.fields(), &value_set);
         let attributes = if let Some(local_parent_id) = local_parent_id {
             Attributes::child_of(local_parent_id.clone(), metadata, &value_set)
+        } else if let Some(id) = self.root_span.as_ref() {
+            Attributes::child_of(id.clone(), metadata, &value_set)
         } else {
-            Attributes::new(metadata, &value_set)
+            Attributes::new_root(metadata, &value_set)
         };
 
         Ok(Self::dispatch(|dispatch| dispatch.new_span(&attributes)))
@@ -521,11 +526,11 @@ impl TracingEventReceiver {
                 let values = Self::expand_fields(&values);
                 let values = Self::create_values(metadata.fields(), &values);
                 let parent = parent.map(|id| self.map_span_id(id)).transpose()?.flatten();
-                let event = if let Some(parent) = parent {
-                    Event::new_child_of(parent.clone(), metadata, &values)
-                } else {
-                    Event::new(metadata, &values)
-                };
+                let event = Event::new_child_of(
+                    parent.or(self.root_span.as_ref()).cloned(),
+                    metadata,
+                    &values,
+                );
                 Self::dispatch(|dispatch| dispatch.event(&event));
             }
         }

--- a/tunnel/src/receiver/tests.rs
+++ b/tunnel/src/receiver/tests.rs
@@ -184,7 +184,7 @@ fn restoring_spans() {
     };
     let local_spans = LocalSpans::default();
 
-    let mut receiver = TracingEventReceiver::new(metadata, spans, local_spans);
+    let mut receiver = TracingEventReceiver::new(metadata, spans, local_spans, None);
     visit_and_drop_span(&mut receiver);
 }
 
@@ -217,7 +217,7 @@ fn restoring_span_after_recording_values() {
     };
     let local_spans = LocalSpans::default();
 
-    let mut receiver = TracingEventReceiver::new(metadata, spans, local_spans);
+    let mut receiver = TracingEventReceiver::new(metadata, spans, local_spans, None);
     receiver.receive(TracingEvent::ValuesRecorded {
         id: 1,
         values: TracedValues::from_iter([("i".to_owned(), TracedValue::from(42_i64))]),

--- a/tunnel/src/sender.rs
+++ b/tunnel/src/sender.rs
@@ -1,19 +1,28 @@
 //! Client-side subscriber.
 
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::{
+    cell::{self, RefCell},
+    sync::atomic::{AtomicU32, Ordering},
+};
 
+use thread_local::ThreadLocal;
 use tracing_core::{
     span::{Attributes, Id, Record},
     Event, Interest, Metadata, Subscriber,
 };
 
-use crate::{CallSiteData, MetadataId, RawSpanId, TracedValues, TracingEvent};
+use crate::{stack::SpanStack, CallSiteData, MetadataId, RawSpanId, TracedValues, TracingEvent};
 
 impl TracingEvent {
-    fn new_span(span: &Attributes<'_>, metadata_id: MetadataId, id: RawSpanId) -> Self {
+    fn new_span(
+        span: &Attributes<'_>,
+        context_parent: impl FnOnce() -> Option<u64>,
+        metadata_id: MetadataId,
+        id: RawSpanId,
+    ) -> Self {
         Self::NewSpan {
             id,
-            parent_id: span.parent().map(Id::into_u64),
+            parent_id: span.parent().map(Id::into_u64).or_else(context_parent),
             metadata_id,
             values: TracedValues::from_values(span.values()),
         }
@@ -26,10 +35,14 @@ impl TracingEvent {
         }
     }
 
-    fn new_event(event: &Event<'_>, metadata_id: MetadataId) -> Self {
+    fn new_event(
+        event: &Event<'_>,
+        context_parent: impl FnOnce() -> Option<u64>,
+        metadata_id: MetadataId,
+    ) -> Self {
         Self::NewEvent {
             metadata_id,
-            parent: event.parent().map(Id::into_u64),
+            parent: event.parent().map(Id::into_u64).or_else(context_parent),
             values: TracedValues::from_event(event),
         }
     }
@@ -50,6 +63,7 @@ impl TracingEvent {
 #[derive(Debug)]
 pub struct TracingEventSender<F = fn(TracingEvent)> {
     next_span_id: AtomicU32,
+    current_spans: ThreadLocal<RefCell<SpanStack>>,
     on_event: F,
 }
 
@@ -58,6 +72,7 @@ impl<F: Fn(TracingEvent) + 'static> TracingEventSender<F> {
     pub fn new(on_event: F) -> Self {
         Self {
             next_span_id: AtomicU32::new(1), // 0 is invalid span ID
+            current_spans: ThreadLocal::new(),
             on_event,
         }
     }
@@ -68,6 +83,10 @@ impl<F: Fn(TracingEvent) + 'static> TracingEventSender<F> {
 
     fn send(&self, event: TracingEvent) {
         (self.on_event)(event);
+    }
+
+    fn span_stack(&self) -> cell::Ref<'_, SpanStack> {
+        self.current_spans.get_or_default().borrow()
     }
 }
 
@@ -88,7 +107,12 @@ impl<F: Fn(TracingEvent) + 'static> Subscriber for TracingEventSender<F> {
     fn new_span(&self, span: &Attributes<'_>) -> Id {
         let metadata_id = Self::metadata_id(span.metadata());
         let span_id = u64::from(self.next_span_id.fetch_add(1, Ordering::SeqCst));
-        self.send(TracingEvent::new_span(span, metadata_id, span_id));
+        self.send(TracingEvent::new_span(
+            span,
+            || self.span_stack().current().map(Id::into_u64),
+            metadata_id,
+            span_id,
+        ));
         Id::from_u64(span_id)
     }
 
@@ -105,16 +129,29 @@ impl<F: Fn(TracingEvent) + 'static> Subscriber for TracingEventSender<F> {
 
     fn event(&self, event: &Event<'_>) {
         let metadata_id = Self::metadata_id(event.metadata());
-        self.send(TracingEvent::new_event(event, metadata_id));
+        self.send(TracingEvent::new_event(
+            event,
+            || self.span_stack().current().map(Id::into_u64),
+            metadata_id,
+        ));
     }
 
     fn enter(&self, span: &Id) {
+        self.current_spans
+            .get_or_default()
+            .borrow_mut()
+            .push(span.clone());
+
         self.send(TracingEvent::SpanEntered {
             id: span.into_u64(),
         });
     }
 
     fn exit(&self, span: &Id) {
+        if let Some(spans) = self.current_spans.get() {
+            spans.borrow_mut().pop(span);
+        }
+
         self.send(TracingEvent::SpanExited {
             id: span.into_u64(),
         });

--- a/tunnel/src/stack.rs
+++ b/tunnel/src/stack.rs
@@ -1,0 +1,77 @@
+pub(crate) use tracing_core::span::Id;
+
+#[derive(Debug)]
+struct ContextId {
+    id: Id,
+    duplicate: bool,
+}
+
+/// `SpanStack` tracks what spans are currently executing on a thread-local basis.
+///
+/// A "separate current span" for each thread is a semantic choice, as each span
+/// can be executing in a different thread.
+#[derive(Debug, Default)]
+pub(crate) struct SpanStack {
+    stack: Vec<ContextId>,
+}
+
+impl SpanStack {
+    #[inline]
+    pub(super) fn push(&mut self, id: Id) -> bool {
+        let duplicate = self.stack.iter().any(|i| i.id == id);
+        self.stack.push(ContextId { id, duplicate });
+        !duplicate
+    }
+
+    #[inline]
+    pub(super) fn pop(&mut self, expected_id: &Id) -> bool {
+        if let Some((idx, _)) = self
+            .stack
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, ctx_id)| ctx_id.id == *expected_id)
+        {
+            let ContextId { id: _, duplicate } = self.stack.remove(idx);
+            return !duplicate;
+        }
+        false
+    }
+
+    #[inline]
+    pub(super) fn iter(&self) -> impl Iterator<Item = &Id> {
+        self.stack
+            .iter()
+            .rev()
+            .filter_map(|ContextId { id, duplicate }| if !*duplicate { Some(id) } else { None })
+    }
+
+    #[inline]
+    pub(super) fn current(&self) -> Option<&Id> {
+        self.iter().next()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Id, SpanStack};
+
+    #[test]
+    fn pop_last_span() {
+        let mut stack = SpanStack::default();
+        let id = Id::from_u64(1);
+        stack.push(id.clone());
+
+        assert!(stack.pop(&id));
+    }
+
+    #[test]
+    fn pop_first_span() {
+        let mut stack = SpanStack::default();
+        stack.push(Id::from_u64(1));
+        stack.push(Id::from_u64(2));
+
+        let id = Id::from_u64(1);
+        assert!(stack.pop(&id));
+    }
+}

--- a/tunnel/tests/integration/main.rs
+++ b/tunnel/tests/integration/main.rs
@@ -3,16 +3,18 @@
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
-    iter, thread,
+    iter,
+    sync::{Arc, Mutex},
+    thread,
 };
 
 use assert_matches::assert_matches;
 use once_cell::sync::Lazy;
-use tracing_core::{Level, Subscriber};
-use tracing_subscriber::{registry::LookupSpan, FmtSubscriber};
+use tracing_core::{Field, Level, Subscriber};
+use tracing_subscriber::{layer::SubscriberExt, registry::LookupSpan, FmtSubscriber};
 use tracing_tunnel::{
     CallSiteKind, LocalSpans, PersistedMetadata, PersistedSpans, TracedValue, TracingEvent,
-    TracingEventReceiver, TracingLevel,
+    TracingEventReceiver, TracingEventSender, TracingLevel,
 };
 
 mod fib;
@@ -321,4 +323,111 @@ fn assert_valid_refs(events: &[TracingEvent]) {
             _ => { /* do nothing */ }
         }
     }
+}
+
+fn sender_events_from_concurrent_threads() -> Vec<TracingEvent> {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let events_event_sender = events.clone();
+    let barrier = std::sync::Barrier::new(2);
+    let event_sender = Arc::new(TracingEventSender::new(move |event| {
+        events_event_sender.lock().unwrap().push(event);
+    }));
+    thread::scope(|s| {
+        s.spawn(|| {
+            tracing::subscriber::with_default(event_sender.clone(), || {
+                tracing::info_span!("a_span", span_thread = 1).in_scope(|| {
+                    barrier.wait();
+                    tracing::info!(event_thread = 1);
+                    barrier.wait();
+                });
+            });
+        });
+        s.spawn(|| {
+            tracing::subscriber::with_default(event_sender.clone(), || {
+                tracing::info_span!("a_span", span_thread = 2).in_scope(|| {
+                    barrier.wait();
+                    tracing::info!(event_thread = 2);
+                    barrier.wait();
+                });
+            });
+        });
+    });
+    drop(event_sender); // Ensure the sender is dropped before we access the events.
+    Arc::into_inner(events).unwrap().into_inner().unwrap()
+}
+
+#[test]
+#[allow(clippy::needless_collect)] // necessary for threads to be concurrent
+fn sender_concurrent_threads() {
+    Lazy::force(&EVENTS);
+
+    struct EventVerifier {
+        errors: Arc<Mutex<Vec<String>>>,
+    }
+    struct SpanThread(String);
+
+    impl<S> tracing_subscriber::Layer<S> for EventVerifier
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+    {
+        fn on_new_span(
+            &self,
+            attrs: &tracing_core::span::Attributes<'_>,
+            id: &tracing_core::span::Id,
+            ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            attrs.record(&mut |field: &Field, val: &dyn std::fmt::Debug| {
+                if field.name() == "span_thread" {
+                    if let Some(span) = ctx.span(id) {
+                        span.extensions_mut().insert(SpanThread(format!("{val:?}")));
+                    }
+                }
+            });
+        }
+
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if let Some(span) = ctx.event_span(event) {
+                let span_thread = span.extensions().get::<SpanThread>().unwrap().0.clone();
+                let mut event_thread = None;
+                event.record(&mut |field: &Field, val: &dyn std::fmt::Debug| {
+                    if field.name() == "event_thread" {
+                        event_thread = Some(format!("{val:?}"));
+                    }
+                });
+                if event_thread.as_ref().unwrap() != &span_thread {
+                    self.errors.lock().unwrap().push(format!(
+                        "Event thread ({}) does not match span thread ({}) for event: {}",
+                        event_thread.unwrap(),
+                        span_thread,
+                        event.metadata().name()
+                    ));
+                }
+            } else {
+                self.errors
+                    .lock()
+                    .unwrap()
+                    .push(format!("Event without parent: {}", event.metadata().name()));
+            }
+        }
+    }
+
+    let events = sender_events_from_concurrent_threads();
+    let event_errors = Arc::new(Mutex::new(Vec::new()));
+    tracing::subscriber::with_default(
+        tracing_subscriber::Registry::default().with(EventVerifier {
+            errors: event_errors.clone(),
+        }),
+        || {
+            let mut event_receiver = TracingEventReceiver::default();
+            for event in events.iter() {
+                event_receiver.receive(event.clone());
+            }
+        },
+    );
+
+    assert_eq!(&*event_errors.lock().unwrap(), &Vec::<String>::new());
 }

--- a/tunnel/tests/integration/main.rs
+++ b/tunnel/tests/integration/main.rs
@@ -208,7 +208,7 @@ fn persisting_metadata() {
     assert!(names.contains("compute"), "{names:?}");
 
     // Check that `receiver` can function after restoring `persisted` meta.
-    let mut receiver = TracingEventReceiver::new(metadata, spans, local_spans);
+    let mut receiver = TracingEventReceiver::new(metadata, spans, local_spans, None);
     tracing::subscriber::with_default(create_fmt_subscriber(), || {
         for event in events {
             if !matches!(event, TracingEvent::NewCallSite { .. }) {
@@ -248,7 +248,8 @@ fn test_persisting_spans(reset_local_spans: bool) {
                 local_spans = LocalSpans::default();
             }
 
-            let mut receiver = TracingEventReceiver::new(metadata.clone(), spans, local_spans);
+            let mut receiver =
+                TracingEventReceiver::new(metadata.clone(), spans, local_spans, None);
             for event in events {
                 receiver.receive(event.clone());
             }
@@ -357,11 +358,11 @@ fn sender_events_from_concurrent_threads() -> Vec<TracingEvent> {
 }
 
 #[test]
-#[allow(clippy::needless_collect)] // necessary for threads to be concurrent
 fn sender_concurrent_threads() {
     Lazy::force(&EVENTS);
 
     struct EventVerifier {
+        expected_root: Arc<Mutex<Option<tracing::span::Id>>>,
         errors: Arc<Mutex<Vec<String>>>,
     }
     struct SpanThread(String);
@@ -376,6 +377,14 @@ fn sender_concurrent_threads() {
             id: &tracing_core::span::Id,
             ctx: tracing_subscriber::layer::Context<'_, S>,
         ) {
+            let expected_root = self.expected_root.lock().unwrap();
+            let span_parent = ctx.span(id).unwrap().parent().map(|s| s.id());
+            if expected_root.as_ref() != span_parent.as_ref() {
+                self.errors.lock().unwrap().push(format!(
+                    "Span {:?} has unexpected parent: {:?}, expected: {:?}",
+                    id, span_parent, expected_root
+                ));
+            }
             attrs.record(&mut |field: &Field, val: &dyn std::fmt::Debug| {
                 if field.name() == "span_thread" {
                     if let Some(span) = ctx.span(id) {
@@ -417,12 +426,22 @@ fn sender_concurrent_threads() {
 
     let events = sender_events_from_concurrent_threads();
     let event_errors = Arc::new(Mutex::new(Vec::new()));
+    let expected_root = Arc::new(Mutex::new(None));
     tracing::subscriber::with_default(
         tracing_subscriber::Registry::default().with(EventVerifier {
+            expected_root: expected_root.clone(),
             errors: event_errors.clone(),
         }),
         || {
-            let mut event_receiver = TracingEventReceiver::default();
+            let _root_guard = tracing::info_span!("root_span").entered();
+            *expected_root.lock().unwrap() = _root_guard.id();
+
+            let mut event_receiver = TracingEventReceiver::new(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                _root_guard.id(),
+            );
             for event in events.iter() {
                 event_receiver.receive(event.clone());
             }

--- a/tunnel/tests/integration/snapshots/integration__events-fib-5.snap
+++ b/tunnel/tests/integration/snapshots/integration__events-fib-5.snap
@@ -1,6 +1,6 @@
 ---
 source: tunnel/tests/integration/main.rs
-assertion_line: 39
+assertion_line: 40
 expression: events
 ---
 - new_call_site:
@@ -37,6 +37,7 @@ expression: events
       - count
 - new_event:
     metadata_id: 1
+    parent: 1
     values:
       message:
         object: count looks somewhat large
@@ -54,6 +55,7 @@ expression: events
       - count
 - new_span:
     id: 2
+    parent_id: 1
     metadata_id: 2
     values:
       count:
@@ -74,6 +76,7 @@ expression: events
       - current
 - new_event:
     metadata_id: 3
+    parent: 2
     values:
       message:
         object: performing iteration
@@ -83,6 +86,7 @@ expression: events
         u_int: 0
 - new_event:
     metadata_id: 3
+    parent: 2
     values:
       message:
         object: performing iteration
@@ -92,6 +96,7 @@ expression: events
         u_int: 1
 - new_event:
     metadata_id: 3
+    parent: 2
     values:
       message:
         object: performing iteration
@@ -101,6 +106,7 @@ expression: events
         u_int: 1
 - new_event:
     metadata_id: 3
+    parent: 2
     values:
       message:
         object: performing iteration
@@ -110,6 +116,7 @@ expression: events
         u_int: 2
 - new_event:
     metadata_id: 3
+    parent: 2
     values:
       message:
         object: performing iteration
@@ -129,6 +136,7 @@ expression: events
       - return
 - new_event:
     metadata_id: 4
+    parent: 2
     values:
       return:
         object: "5"
@@ -149,6 +157,7 @@ expression: events
       - result
 - new_event:
     metadata_id: 5
+    parent: 1
     values:
       message:
         object: computed Fibonacci number
@@ -158,4 +167,3 @@ expression: events
     id: 1
 - span_dropped:
     id: 1
-


### PR DESCRIPTION
## Summary

**BREAKING:** `TracingEventReceiver::new()` now takes an additional `root_span: Option<Id>` parameter.

Previously, spans and events arriving without a parent were replayed using contextual parent lookup (`Attributes::new`), non-deterministically attaching to whatever span happened to be current on the receiver thread. This made receiver output dependent on ambient subscriber state.

- Accept an explicit `root_span` in `TracingEventReceiver::new()`
- Parentless spans/events are attached to `root_span` via `Attributes::child_of`
- When no `root_span` is provided, create explicit roots (`Attributes::new_root`) instead of using contextual lookup

Depends on #75.